### PR TITLE
Update for 7.40/7.40h1/7.40h2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Iolite **is not** a private server, it never will be. This project is research p
 - Oodle `oo2net_9_win64.dll` (optionally `oo2net_9_win64.lib`)
 - A legit copy of the game
 
-### Supported game version: 7.40
+### Supported game version: 7.40h1
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Iolite **is not** a private server, it never will be. This project is research p
 - Oodle `oo2net_9_win64.dll` (optionally `oo2net_9_win64.lib`)
 - A legit copy of the game
 
-### Supported game version: 7.38
+### Supported game version: 7.40
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Iolite **is not** a private server, it never will be. This project is research p
 - Oodle `oo2net_9_win64.dll` (optionally `oo2net_9_win64.lib`)
 - A legit copy of the game
 
-### Supported game version: 7.40h1
+### Supported game version: 7.40h2
 
 ## Configuration
 

--- a/src/structs/zone_ipc_def.rs
+++ b/src/structs/zone_ipc_def.rs
@@ -3,25 +3,25 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u16)]
 pub enum ServerZoneIpcType {
-  Ping = 0x30d,     // 7.40h1
-  Init = 0x278,     // 7.40h1
-  InitZone = 0x12e, // 7.40h1
+  Ping = 0x1a0,     // 7.40h2
+  Init = 0x250,     // 7.40h2
+  InitZone = 0x242, // 7.40h2
 
-  PlayerStats = 0x2bf,     // 7.40h1
-  PlayerSetup = 0x36f,     // 7.40h1
-  PlayerClassInfo = 0x379, // 7.40h1
-  PlayerSpawn = 0x18b,     // 7.40h1
+  PlayerStats = 0x1e1,     // 7.40h2
+  PlayerSetup = 0x256,     // 7.40h2
+  PlayerClassInfo = 0x0a0, // 7.40h2
+  PlayerSpawn = 0x0ca,     // 7.40h2
 
-  ActorControlSelf = 0x38a, // 7.40h1
+  ActorControlSelf = 0x347, // 7.40h2
 }
 
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u16)]
 pub enum ClientZoneIpcType {
   None,
-  PingHandler = 0x2d6,          // 7.40h1
-  InitHandler = 0x164,          // 7.40h1
-  FinishLoadingHandler = 0x0c9, // 7.40h1
+  PingHandler = 0x142,          // 7.40h2
+  InitHandler = 0x312,          // 7.40h2
+  FinishLoadingHandler = 0x324, // 7.40h2
 }
 
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]

--- a/src/structs/zone_ipc_def.rs
+++ b/src/structs/zone_ipc_def.rs
@@ -3,25 +3,25 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u16)]
 pub enum ServerZoneIpcType {
-  Ping = 0x3E2,     // 7.38
-  Init = 0x277,     // 7.38
-  InitZone = 0x2B1, // 7.38
+  Ping = 0x1df,     // 7.40
+  Init = 0x184,     // 7.40
+  InitZone = 0x175, // 7.40
 
-  PlayerStats = 0x2C4,     // 7.38
-  PlayerSetup = 0x39A,     // 7.38
-  PlayerClassInfo = 0x204, // 7.38
-  PlayerSpawn = 0x270,     // 7.38
+  PlayerStats = 0x160,     // 7.40
+  PlayerSetup = 0x90,     // 7.40
+  PlayerClassInfo = 0xac, // 7.40
+  PlayerSpawn = 0x107,     // 7.40
 
-  ActorControlSelf = 0x254, // 7.38
+  ActorControlSelf = 0x1d8, // 7.40
 }
 
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u16)]
 pub enum ClientZoneIpcType {
   None,
-  PingHandler = 0x30A,          // 7.38
-  InitHandler = 0x157,          // 7.38
-  FinishLoadingHandler = 0x3A5, // 7.38
+  PingHandler = 0x311,          // 7.40
+  InitHandler = 0x2ec,          // 7.40
+  FinishLoadingHandler = 0x1e5, // 7.40
 }
 
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]

--- a/src/structs/zone_ipc_def.rs
+++ b/src/structs/zone_ipc_def.rs
@@ -3,25 +3,25 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u16)]
 pub enum ServerZoneIpcType {
-  Ping = 0x1df,     // 7.40
-  Init = 0x184,     // 7.40
-  InitZone = 0x175, // 7.40
+  Ping = 0x30d,     // 7.40h1
+  Init = 0x278,     // 7.40h1
+  InitZone = 0x12e, // 7.40h1
 
-  PlayerStats = 0x160,     // 7.40
-  PlayerSetup = 0x90,     // 7.40
-  PlayerClassInfo = 0xac, // 7.40
-  PlayerSpawn = 0x107,     // 7.40
+  PlayerStats = 0x2bf,     // 7.40h1
+  PlayerSetup = 0x36f,     // 7.40h1
+  PlayerClassInfo = 0x379, // 7.40h1
+  PlayerSpawn = 0x18b,     // 7.40h1
 
-  ActorControlSelf = 0x1d8, // 7.40
+  ActorControlSelf = 0x38a, // 7.40h1
 }
 
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u16)]
 pub enum ClientZoneIpcType {
   None,
-  PingHandler = 0x311,          // 7.40
-  InitHandler = 0x2ec,          // 7.40
-  FinishLoadingHandler = 0x1e5, // 7.40
+  PingHandler = 0x2d6,          // 7.40h1
+  InitHandler = 0x164,          // 7.40h1
+  FinishLoadingHandler = 0x0c9, // 7.40h1
 }
 
 #[derive(Debug, Eq, PartialEq, IntoPrimitive, TryFromPrimitive)]


### PR DESCRIPTION
This PR adds support for patches 7.40, 7.40h1, and 7.40h2. It does not currently account for changes in PlayerSetup; I'll try to port our changes from Kawari over at a later date.